### PR TITLE
Corrected default for fastcraft.use

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Required parameters have &lt;angle brackets&gt;. Optional parameters have [squar
 |Default|Permission|Use|
 |---|---|---|
 |op|fastcraft.*|All FastCraft+ permissions|
-|op|fastcraft.use|Permission to use FastCraft+ for crafting|
+|true|fastcraft.use|Permission to use FastCraft+ for crafting|
 |false|fastcraft.command.*|Permission to use all non-admin commands|
 |true|fastcraft.command.toggle|/fastcraft toggle [on/off/toggle]|
 |op|fastcraft.command.toggle.other|/fastcraft toggle [on/off/toggle] [player]|


### PR DESCRIPTION
Documentation doesn't match plugin.yml, which I assume has the intended behavior.